### PR TITLE
byte slice comparison update

### DIFF
--- a/gopass_test.go
+++ b/gopass_test.go
@@ -147,14 +147,14 @@ func TestComparePasswords(t *testing.T) {
 	}
 
 	// Test valid comparison
-	valid := gp.ComparePasswords(hashedPass, salt, password)
+	valid, _ := gp.ComparePasswords(hashedPass, salt, password)
 	if !valid {
 		t.Errorf("Expected password to be valid")
 	}
 
 	// Test invalid comparison (wrong password)
 	invalidPassword := "incorrectHorseBatteryStaple"
-	valid = gp.ComparePasswords(hashedPass, salt, invalidPassword)
+	valid, _ = gp.ComparePasswords(hashedPass, salt, invalidPassword)
 	if valid {
 		t.Errorf("Expected password to be invalid")
 	}


### PR DESCRIPTION
Swapped out byte slice comparison function to prevent against timing attacks and updated tests. Special thanks to destel116 of the Reddit Go community for the suggestion.